### PR TITLE
Include cid import in 'without magic' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ export default class extends Component {
 ## Alternative usage (without magic)
 ```
 import 'reflect-metadata'; // Import only once
-import { container, inject } from 'inversify-props';
+import { cid, container, inject } from 'inversify-props';
 
 container.addSingleton<IService1>(Service1);
 


### PR DESCRIPTION
Just a small change to the documentation. It seems `cid` is needed to name the service when injecting it 'without magic'. 